### PR TITLE
Render recipe details on click in Sidebar's recipe buttons

### DIFF
--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -50,7 +50,7 @@ const MainContainer = () => {
     const [displayBlobs, setDisplayBlobs] = useState<Boolean>(true);
     const [selectedRecipeImage, setSelectedRecipeImage] = useState<string>("");
     const [recipeInstructions, setRecipeInstructions] = useState<IInstructions[]>([]);
-    const [selectedRecipes, setSelectedRecipes] = useState<string[]>([]);
+    const [selectedRecipes, setSelectedRecipes] = useState<IRecipe[]>([]);
 
 
   //arg: list of ingredients, returns a list of recipes(with recipe IDs used as args for fetchInstructionsById)
@@ -109,16 +109,11 @@ const MainContainer = () => {
   const renderCards = (): JSX.Element[] => {
     if (searchedRecipes.length) {
       const cards = searchedRecipes.map((recipe) => {
-        const { id, title, image, missedIngredients, usedIngredients } = recipe;
 
         return (
           <RecipeCard
-            key={id}
-            id={id}
-            title={title}
-            image={image}
-            missedIngredients={missedIngredients}
-            usedIngredients={usedIngredients}
+            key={recipe.id}
+            recipe={recipe}
             getRecipeDetails={getRecipeDetails}
             setSelectedRecipes={setSelectedRecipes}
           ></RecipeCard>
@@ -127,6 +122,7 @@ const MainContainer = () => {
       return cards;
     } else return [];
   };
+  console.log(`recipes []`, selectedRecipes)
 
   return (
     <Container>
@@ -137,6 +133,7 @@ const MainContainer = () => {
         selectedIngredients={selectedIngredients}
         setSearchedRecipes={setSearchedRecipes}
         selectedRecipes={selectedRecipes}
+        getRecipeDetails={getRecipeDetails}
       />
       <BlobsContainer userSearchedRecipes={userSearchedRecipes}>
         {/* Render Cards/Blobs OR Details */}

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -122,7 +122,7 @@ const MainContainer = () => {
       return cards;
     } else return [];
   };
-  console.log(`recipes []`, selectedRecipes)
+
 
   return (
     <Container>

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,102 +1,99 @@
-import React, {FC} from 'react';
-import {IIngredients } from '../interfaces/Recipe';
-import styled from 'styled-components';
-import PlusIcon from '../assets/plus.svg';
+import React, { FC } from "react";
+import { IIngredients, IRecipe } from "../interfaces/Recipe";
+import styled from "styled-components";
+import PlusIcon from "../assets/plus.svg";
 
 interface RecipeCardProps {
-    id: number;
-    title: string;
-    usedIngredients: IIngredients[];
-    missedIngredients: IIngredients[];
-    image: string;
-    getRecipeDetails: Function;
-    setSelectedRecipes: Function;
+  recipe: IRecipe;
+  getRecipeDetails: Function;
+  setSelectedRecipes: Function;
 }
 
 const FoodCard = styled.div`
-    background-color: #ef8080;
-    border-radius: 15px;
-    position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    flex-direction: column;
-`
-
-const AddBtn = styled.div`
-    width: 50px;
-    height: 50px;
-    background-color: #fff;
-    position: absolute;
-    top: 0;
-    left: 0;
-    border-radius: 15px 0 15px 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-`
-
-const TitleContainer = styled.div`
-    width: 300px;
-    padding-left: 30px;
-    text-align: start;
-    display: flex;
-    flex-wrap: wrap;
-
-    h2 {
-        letter-spacing: 1px;
-        color: #fff;
-    }
-`
-
-const UsedIngredientsContainer = styled.div`
-    width: 300px;
-    padding-left: 30px;
-    text-align: start;
-    margin-top: 15px;
-
-    h3 {
-        color: #fff;
-        letter-spacing: 1px;
-    }
+  background-color: #ef8080;
+  border-radius: 15px;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  flex-direction: column;
 `;
 
+const AddBtn = styled.div`
+  width: 50px;
+  height: 50px;
+  background-color: #fff;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border-radius: 15px 0 15px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
+const TitleContainer = styled.div`
+  width: 300px;
+  padding-left: 30px;
+  text-align: start;
+  display: flex;
+  flex-wrap: wrap;
 
-const RecipeCard: FC<RecipeCardProps> = ({id, title, image, usedIngredients,missedIngredients,  getRecipeDetails, setSelectedRecipes})=> {
+  h2 {
+    letter-spacing: 1px;
+    color: #fff;
+  }
+`;
 
-    const FoodImage = styled.div`
-        width: 50%;
-        background-color: #fff;
-        background-image: url(${image});
-        background-size: cover;
-        background-repeat: no-repeat;
-        height: 100%;
-        position: absolute;
-        right: 0;
-        clip-path: ellipse(50% 53% at 64% 29%);
-    `
+const UsedIngredientsContainer = styled.div`
+  width: 300px;
+  padding-left: 30px;
+  text-align: start;
+  margin-top: 15px;
 
-    const addRecipe = (e: React.MouseEvent<HTMLDivElement>) => {
-        e.stopPropagation();
-        setSelectedRecipes((prevState: string[])=> [...prevState, title]);
-    }
+  h3 {
+    color: #fff;
+    letter-spacing: 1px;
+  }
+`;
 
-    return (
-    <FoodCard onClick={()=>getRecipeDetails(id)}>
+const RecipeCard: FC<RecipeCardProps> = ({
+  recipe,
+  getRecipeDetails,
+  setSelectedRecipes,
+}) => {
+  const FoodImage = styled.div`
+    width: 50%;
+    background-color: #fff;
+    background-image: url(${recipe.image});
+    background-size: cover;
+    background-repeat: no-repeat;
+    height: 100%;
+    position: absolute;
+    right: 0;
+    clip-path: ellipse(50% 53% at 64% 29%);
+  `;
 
-        {/* add onclick to button to add to sidebar */}
-        <AddBtn onClick={e=>addRecipe(e)}>
-            <img src={PlusIcon} alt="plus" />
-        </AddBtn>
-        <FoodImage></FoodImage>
-        <TitleContainer>
-            <h2>{title}</h2>
-        </TitleContainer>
-        <UsedIngredientsContainer>
-            <h3>{missedIngredients.length} Missing Ingredients</h3>
-        </UsedIngredientsContainer>
-    </FoodCard>)
-}
+  const addRecipe = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    setSelectedRecipes((prevState: IRecipe[]) => [...prevState, recipe]);
+  };
+
+  return (
+    <FoodCard onClick={() => getRecipeDetails(recipe.id)}>
+      {/* add onclick to button to add to sidebar */}
+      <AddBtn onClick={(e) => addRecipe(e)}>
+        <img src={PlusIcon} alt="plus" />
+      </AddBtn>
+      <FoodImage></FoodImage>
+      <TitleContainer>
+        <h2>{recipe.title}</h2>
+      </TitleContainer>
+      <UsedIngredientsContainer>
+        <h3>{recipe.missedIngredients.length} Missing Ingredients</h3>
+      </UsedIngredientsContainer>
+    </FoodCard>
+  );
+};
 
 export default RecipeCard;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,8 @@ import React, { FC } from 'react'
 import styled from 'styled-components'
 import SearchBar from './SearchBar'
 import IngredientButton from './IngredientButton'
-import FindRecipesBtn from './FindRecipesBtn'
+import FindRecipesBtn from './FindRecipesBtn';
+import {IRecipe} from '../interfaces/Recipe'
 
 const SidebarContainer = styled.div`
   grid-area: 1 / 1 / 2 / 2;
@@ -42,7 +43,8 @@ interface SidebarProps {
   searchByIngredients: Function;
   setSearchedRecipes: Function;
   setUserSearchedRecipes: Function;
-  selectedRecipes: string[];
+  selectedRecipes: IRecipe[];
+  getRecipeDetails: Function;
 }
 
 const Sidebar: FC<SidebarProps> = ({
@@ -51,7 +53,8 @@ const Sidebar: FC<SidebarProps> = ({
   selectedRecipes,
   searchByIngredients,
   setSearchedRecipes,
-  setUserSearchedRecipes
+  setUserSearchedRecipes,
+  getRecipeDetails,
 }) => {
   
   const searchRecipesOnClick = async () => {
@@ -72,11 +75,13 @@ const Sidebar: FC<SidebarProps> = ({
     ))
   }
 
+  //add onclick to getRecipeDetails to listed recipes in sidebar
   const renderRecipesList = () => {
-    return selectedRecipes?.map((recipeName) => {
+    return selectedRecipes?.map((recipe) => {
       return <RecipeBtn
-        key={recipeName}
-        >{recipeName}
+        key={recipe.id}
+        onClick={()=>getRecipeDetails(recipe.id)}
+        >{recipe.title}
       </RecipeBtn>
       
     })


### PR DESCRIPTION

## Changes
1. Changed interface for `selectedRecipes` hook from `string[]`(recipe titles) to `IRecipe[]` to give Sidebar access to `recipe.id`.
2. Refactored `RecipeCard` to have the whole `recipe` object passed down, instead of `title, id, image, missedIngredient, usedIngredients` only, and imported `IRecipe` interface.
3. Refactored `renderRecipesList` in Sidebar to map with `recipe` as parameter instead of `recipeName` and have it return buttons with correct props.

## Purpose
Allow user to click on sidebar recipe buttons to render recipe details by ID.

## Approach
Refactor & react typescript.

Closes #38 